### PR TITLE
light edits and fixed links

### DIFF
--- a/01-invited/first-lesson.md
+++ b/01-invited/first-lesson.md
@@ -12,6 +12,7 @@ This is the gold! 💰
 
 Ask your mentor and read [this section](../02-creating-lessons/ideas.md) about figuring out the core concept for your first example.
 
+
 ### Where to stop?
 
 On the other side of the coin, we need to determine where to stop! Knowing where to stop is determined by the scope of the lesson you are trying to teach.

--- a/01-invited/getting-paid.md
+++ b/01-invited/getting-paid.md
@@ -62,7 +62,7 @@ Sound good to you?
 
 The one-off lessons is a **great** way to build your catalog, see a little revenue, and keep your screen-casting muscles strong in between courses.
 
-The expectation here is that you will create lessons that follow the egghead.io standards outlined in [the Instructor Guide](https://instructor.egghead.io). Give them good names, summaries, tags, and code samples. As control freaks, this is a big step for us 😂, but we trust you to publish your best. Feel free to [ask for feedback in the instructor channel on egghead.io Slack](https://eggheadio.slack.com/archives/egghead-instructors).
+The expectation here is that you will create lessons that follow the egghead.io standards outlined in [the Instructor Guide](../02-creating-lessons/ideas.md). Give them good names, summaries, tags, and code samples. As control freaks, this is a big step for us 😂, but we trust you to publish your best. Feel free to [ask for feedback in the instructor channel on egghead.io Slack](https://eggheadio.slack.com/archives/egghead-instructors).
 
 ![with great power](https://d3vv6lp55qjaqc.cloudfront.net/items/1X3d0U2x2I3Y060s1s0B/Image%202016-09-29%20at%204.44.02%20PM.gif?v=def0754b)
 

--- a/02-creating-lessons/how-to-deliver-code-for-egghead-lessons-and-courses.md
+++ b/02-creating-lessons/how-to-deliver-code-for-egghead-lessons-and-courses.md
@@ -21,14 +21,14 @@ Linking a Github repository to plunker is fairly simple and involves configuring
 To link to Github we configure the url by adding:
 
 
-      `https://embed.plnkr.co/github/{profile-name}/{repository}/{branch}` 
+      https://embed.plnkr.co/github/{profile-name}/{repository}/{branch} 
 
 `{branch}` can be replaced with `{tag|sha1}`  depending on how your repo is set up. If your repo is set up with an example in individual folders, you can add that `/path` to the embed url.
 
 [Click here to see an example repo.](https://github.com/eggheadio-projects/nlp-in-javascript-with-natural) This is divided into a folder per lesson.
 
 
-https://d2mxuefqeaa7sj.cloudfront.net/s_8105448CE6BE7B09A22ECBB05188409410D34AA6CBCE3636EE692CDF03958981_1488045591787_file.png
+![](https://d2mxuefqeaa7sj.cloudfront.net/s_8105448CE6BE7B09A22ECBB05188409410D34AA6CBCE3636EE692CDF03958981_1488045591787_file.png)
 
 
 
@@ -80,12 +80,12 @@ This will give a *verbose* working example of the config file needed to achieve 
       </body>
     </html>
 
-You will then need to create an `app.js` ****file in the `src` directory `src/app.js` . This file will contain the code you want to run.
+You will then need to create an `app.js` file in the `src` directory `src/app.js` . This file will contain the code you want to run.
 Any packages that are installed using `jspm i npm:{package_you_want_to_install}` will create a `jspm_packages/npm/{package_you_want_to_install}@1.2.3.json` file.
  
 **Copy those contents.** 
 
-The content will be placed in your `SystemJS.config` ****under the `packages` property as the package you installed.
+The content will be placed in your `SystemJS.config` under the `packages` property as the package you installed.
 Eg:
 
     SystemJS.config({
@@ -114,7 +114,7 @@ Eg:
       }
     });
 
-**Jspm** will also give you a ****`jspm.config.js` file that we will want to copy with some slight modifications
+**Jspm** will also give you a `jspm.config.js` file that we will want to copy with some slight modifications
 
 
     SystemJS.config({
@@ -146,13 +146,13 @@ Eg:
 
 Note that the `"baseURL":` property was changed from `/` to a `.` 
  
-Also note that `"systemjs-babel-build": "npm:systemjs-plugin-babel/systemjs-babel-browser.js` **** line was added under the `map` ****property (nested in the `devConfig` property).
+Also note that `"systemjs-babel-build": "npm:systemjs-plugin-babel/systemjs-babel-browser.js` line was added under the `map` property (nested in the `devConfig` property).
 
 For plunker apps just add this script tag (in `index.html` ):
 `<script src="https://unpkg.com/systemjs@0.19.41/dist/system.src.js"></script>` 
-Then the two `SystemJS.config` ****objects can be added in their own script, and you should be good to go!
+Then the two `SystemJS.config` objects can be added in their own script, and you should be good to go!
 
-Shout out to @John L for the walkthrough on in-browser compiling. 🙌 
+Shout out to John Lindquist for the walkthrough on in-browser compiling. 🙌 
 
 Example for further clarity: 
 http://embed.plnkr.co/UxkIoIK9PEkaupwTInDE?show=script.js,preview

--- a/02-creating-lessons/how-to-deliver-code-for-egghead-lessons-and-courses.md
+++ b/02-creating-lessons/how-to-deliver-code-for-egghead-lessons-and-courses.md
@@ -21,7 +21,7 @@ Linking a Github repository to plunker is fairly simple and involves configuring
 To link to Github we configure the url by adding:
 
 
-      https://embed.plnkr.co/github/{profile-name}/{repository}/{branch} 
+`https://embed.plnkr.co/github/{profile-name}/{repository}/{branch}`
 
 `{branch}` can be replaced with `{tag|sha1}`  depending on how your repo is set up. If your repo is set up with an example in individual folders, you can add that `/path` to the embed url.
 

--- a/02-creating-lessons/recording-the-screen.md
+++ b/02-creating-lessons/recording-the-screen.md
@@ -144,7 +144,7 @@ You can "kick it up a notch BAM!💥" and move into more sophisticated editing t
 
 * [John Lindquist doing some diting in Premiere](https://www.youtube.com/watch?v=_YqhKP-yZzo&index=1&list=PL219naRJXQKbQJ60WxsuGfTFv7_fvna51)
 * [JS Leonard walks through his process using Premiere](https://www.youtube.com/watch?v=faINApx4-4g&list=PL219naRJXQKbQJ60WxsuGfTFv7_fvna51&index=2)
-* [Joel Hooks does voice over and editing in Premiere](https://www.youtube.com/watch?v=faINApx4-4g&list=PL219naRJXQKbQJ60WxsuGfTFv7_fvna51&index=2)
+* [Joel Hooks does voice over and editing in Premiere](https://www.youtube.com/watch?v=QNFsYy6gCgU&list=PL219naRJXQKbQJ60WxsuGfTFv7_fvna51&index=4)
 
 This video will show you how you can record in "chunks":
 

--- a/03-creating-courses/create-courses.md
+++ b/03-creating-courses/create-courses.md
@@ -77,7 +77,7 @@ The course summary is a paragraph or two that describes the course, goals, techn
 
 ### Lesson List
 
-Finally, we have the actual list of lessons that will be in the course. The list consists of **lesson titles and summaries** for each individual lesson. The title should follow [the "how do I..." format](/how-do-i), and the summary should summarize the goals and technology that the student will learn about in the lesson.
+Finally, we have the actual list of lessons that will be in the course. The list consists of **lesson titles and summaries** for each individual lesson. The title should follow [the "how do I..." format](../02-creating-lessons/ideas.html#a-strong-title-is-key), and the summary should summarize the goals and technology that the student will learn about in the lesson.
 
 ## The Examples
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,8 +11,7 @@
     * [The Lesson Concept](02-creating-lessons/ideas.md)
     * [Recording the Screencast](02-creating-lessons/recording-the-screen.md)
     * [Audio Equipment Setup](02-creating-lessons/recording-gear.md)
-    * [Setup Code Examples](02-creating-lessons/how-to-deliver-code-for-egghead-lessons-and-courses.md
-)    
+    * [Setup Code Examples](02-creating-lessons/how-to-deliver-code-for-egghead-lessons-and-courses.md)    
     * [Resources for Ideas](02-creating-lessons/resources-for-ideas.md)
 * [Creating an egghead Course](03-creating-courses/create-courses.md)
 


### PR DESCRIPTION

- fixed a few typos
- changed broken link to direct to a specific header

Gitbook has some [good documentation](https://seadude.gitbooks.io/learn-gitbook/content/chapter1/internal.html) on using internal links to redirect to different headers/sections.

![screen recording 2017-02-27 at 03 06 pm](https://cloud.githubusercontent.com/assets/6188161/23384144/64bf1fd8-fcfe-11e6-9d37-02b29c046208.gif)


![](https://media.giphy.com/media/5r5J4JD9miis/giphy.gif
)
